### PR TITLE
Clean TV page and enforce typed rate handler

### DIFF
--- a/client/src/pages/tv.ts
+++ b/client/src/pages/tv.ts
@@ -5,20 +5,36 @@ import { generateQr } from '../lib/qr';
 import { controlDrift } from '../lib/drift';
 import { getDeviceId } from '../lib/device';
 
+declare global {
+  interface Window {
+    tvSyncInterval?: number;
+  }
+}
+
 export async function initTvPage(root: HTMLElement, roomId: string): Promise<void> {
   root.innerHTML = `
     <div class="flex flex-col items-center justify-center h-full">
-      <video id="video" class="w-full max-h-full bg-black" muted autoplay loop playsinline></video>
       <canvas id="qr" class="mt-4"></canvas>
     </div>
   `;
-  const video = document.getElementById('video') as HTMLVideoElement;
   const qrCanvas = document.getElementById('qr') as HTMLCanvasElement;
-  // Asegurar reproducción sin audio y en bucle
-  video.muted = true;
-  video.loop = true;
 
-  let roomInfo: { src: string; type: 'mp4' | 'hls'; token: string };
+  function ensureVideo(): HTMLVideoElement {
+    let video = document.getElementById('video') as HTMLVideoElement | null;
+    if (!video) {
+      video = document.createElement('video');
+      video.id = 'video';
+      video.className = 'w-full max-h-full bg-black';
+      video.muted = true;
+      video.loop = true;
+      video.autoplay = true;
+      video.playsInline = true;
+      qrCanvas.parentElement!.insertBefore(video, qrCanvas);
+    }
+    return video;
+  }
+
+  let roomInfo: { src: string; type: 'mp4' | 'hls'; token: string; epochScheduled?: number };
   try {
     const res = await fetch(`/rooms/${roomId}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -29,8 +45,8 @@ export async function initTvPage(root: HTMLElement, roomId: string): Promise<voi
     return;
   }
   generateQr(qrCanvas, `${window.location.origin}/controller?room=${roomId}&token=${roomInfo.token}`);
+  const video = ensureVideo();
   console.log('[TV] initial source:', roomInfo.src, 'type:', roomInfo.type);
-  // Carga inicial de la fuente antes de recibir comandos
   if (roomInfo.type === 'hls') {
     setupHls(video, roomInfo.src);
   } else {
@@ -55,7 +71,9 @@ export async function initTvPage(root: HTMLElement, roomId: string): Promise<voi
     video.play();
   });
   socket.on('srv_cmd_pause', () => video.pause());
-  socket.on('srv_cmd_seek', ({ time }) => (video.currentTime = time));
+  socket.on('srv_cmd_seek', ({ time }) => {
+    video.currentTime = time;
+  });
   socket.on('srv_cmd_changeSrc', ({ src, type }) => {
     console.log('[TV] srv_cmd_changeSrc → src=', src, ' type=', type);
     startEpoch = Date.now() + offset;
@@ -66,20 +84,19 @@ export async function initTvPage(root: HTMLElement, roomId: string): Promise<voi
       video.src = src;
       video.load();
     }
-    // Mantener siempre sin audio y en bucle tras cambiar la fuente
     video.muted = true;
     video.loop = true;
-    // Log when metadata and data are loaded
     video.addEventListener('loadedmetadata', () => console.log('[TV] loadedmetadata, duration=', video.duration));
     video.addEventListener('loadeddata', () => console.log('[TV] loadeddata'));
     video.addEventListener('canplay', () => console.log('[TV] canplay'));
   });
-  socket.on('srv_cmd_rate', ({ rate }) => (video.playbackRate = rate));
+  socket.on('srv_cmd_rate', ({ rate }: { rate: number }) => {
+    video.playbackRate = rate;
+  });
 
   // Drift correction loop every 2s
-  // Clear any existing interval to prevent duplicates
-  if ((window as any).tvSyncInterval) clearInterval((window as any).tvSyncInterval);
-  (window as any).tvSyncInterval = setInterval(() => {
+  if (window.tvSyncInterval) clearInterval(window.tvSyncInterval);
+  window.tvSyncInterval = window.setInterval(() => {
     const now = Date.now() + offset;
     const expectedTime = startEpoch ? (now - startEpoch) / 1000 : 0;
     const drift = expectedTime - video.currentTime;
@@ -91,3 +108,4 @@ export async function initTvPage(root: HTMLElement, roomId: string): Promise<voi
 }
 
 // Device ID helper moved to lib/device.ts
+


### PR DESCRIPTION
## Summary
- render QR-only landing and lazily create the video element
- add global Window.tvSyncInterval declaration and typed srv_cmd_rate handler

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a620838c64832c83b0a3bc01f6b454