### PR TITLE
chore: pin typescript to 5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "concurrently": "^7.6.0",
         "eslint": "^8.25.0",
         "eslint-config-prettier": "^8.8.0",
-        "prettier": "^2.8.1"
+        "prettier": "^2.8.1",
+        "typescript": "~5.1.6"
       }
     },
     "client": {
@@ -4199,12 +4200,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "qr-tv-sync",
   "private": true,
   "version": "1.0.0",
-  "workspaces": ["server", "client"],
+  "workspaces": [
+    "server",
+    "client"
+  ],
   "scripts": {
     "dev:server": "cd server && mkdir -p ./.tmp && TS_NODE_DEV_TMPDIR=./.tmp ts-node-dev --cache-directory=./.tmp --respawn --transpile-only src/index.ts",
     "dev:client": "npm --workspace client run dev",
@@ -18,6 +21,7 @@
     "@typescript-eslint/parser": "^5.44.0",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "prettier": "^2.8.1",
-    "eslint-config-prettier": "^8.8.0"
+    "eslint-config-prettier": "^8.8.0",
+    "typescript": "~5.1.6"
   }
 }


### PR DESCRIPTION
## Summary
- pin TypeScript to 5.1.6 to avoid eslint plugin warnings

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62726cf18832ca9e01cf52bde371d